### PR TITLE
Reworked IntegerTextInputFormatter

### DIFF
--- a/lib/utils/common_utils.dart
+++ b/lib/utils/common_utils.dart
@@ -112,9 +112,11 @@ String insertSpaceEveryNthCharacter(String input, int n) {
   return out.trim();
 }
 
-String sanitizeIntegerString(String input, bool allowNegativeValues, bool allowNumberList) {
+String sanitizeIntegerString(String input, {bool allowNegativeValues: true, bool allowNumberList: true}) {
   
   String adaptedText = input ?? '';
+  allowNegativeValues ??= true;
+  allowNumberList ??= true;
   
   if (allowNegativeValues) {
     if (allowNumberList) {
@@ -123,7 +125,8 @@ String sanitizeIntegerString(String input, bool allowNegativeValues, bool allowN
       adaptedText = adaptedText.replaceAllMapped(new RegExp(r'(\d)-'), (Match groups) => "${groups[1]} -");
     } else {
       adaptedText = adaptedText.replaceAll(new RegExp(r'[^\-\d]'), '');
-      adaptedText = adaptedText.replaceAllMapped(new RegExp(r'(\d)-'), (Match groups) => "${groups[1]}");
+      adaptedText = adaptedText.replaceAll(new RegExp(r'-{2,}'), '-');
+      adaptedText = adaptedText.replaceAllMapped(new RegExp(r'(\d)-+'), (Match groups) => "${groups[1]}");
     }
   } else {
     if (allowNumberList) {

--- a/lib/utils/common_utils.dart
+++ b/lib/utils/common_utils.dart
@@ -5,12 +5,12 @@ import 'constants.dart';
 import 'alphabets.dart';
 
 List<int> textToIntList(String text, {bool allowNegativeValues: false}) {
-  var regex = allowNegativeValues ? RegExp(r'[^\-0-9]') : RegExp(r'[^0-9]');
-
-  var list = text.split(regex);
-  list.removeWhere((value) => value == null || value == '');
-
-  return list.map((value) => value == '-' ? 0 : int.tryParse(value)).toList();
+  if ((text == null) || (allowNegativeValues == null))
+    return [];
+  
+  final regex = allowNegativeValues ? RegExp(r'-?\d+') : RegExp(r'\d+');
+  
+  return regex.allMatches(text).map((value) => int.tryParse(text.substring(value.start, value.end))).toList();
 }
 
 int extractIntegerFromText(String text) {
@@ -110,4 +110,29 @@ String insertSpaceEveryNthCharacter(String input, int n) {
   }
 
   return out.trim();
+}
+
+String sanitizeIntegerString(String input, bool allowNegativeValues, bool allowNumberList) {
+  
+  String adaptedText = input ?? '';
+  
+  if (allowNegativeValues) {
+    if (allowNumberList) {
+      adaptedText = adaptedText.replaceAll(new RegExp(r'[^\-\d ]'), ' ');
+      adaptedText = adaptedText.replaceAll(new RegExp(r'\s{2,}'), ' ');
+      adaptedText = adaptedText.replaceAllMapped(new RegExp(r'(\d)-'), (Match groups) => "${groups[1]} -");
+    } else {
+      adaptedText = adaptedText.replaceAll(new RegExp(r'[^\-\d]'), '');
+      adaptedText = adaptedText.replaceAllMapped(new RegExp(r'(\d)-'), (Match groups) => "${groups[1]}");
+    }
+  } else {
+    if (allowNumberList) {
+      adaptedText = adaptedText.replaceAll(new RegExp(r'[^\d ]'), ' ');
+      adaptedText = adaptedText.replaceAll(new RegExp(r'\s{2,}'), ' ');
+    } else {
+      adaptedText = adaptedText.replaceAll(new RegExp(r'\D'), '');
+    }
+  }
+  
+  return adaptedText;
 }

--- a/lib/widgets/common/gcw_integer_list_textfield.dart
+++ b/lib/widgets/common/gcw_integer_list_textfield.dart
@@ -34,15 +34,28 @@ class _GCWIntegerListTextFieldState extends State<GCWIntegerListTextField> {
         hintText: widget.hintText,
         onChanged: (text) {
           setState(() {
-            var list = textToIntList(text, allowNegativeValues: allowNegativeValues);
-            widget.onChanged({'text': text, 'values': list});
+            var values = textToIntList(text, allowNegativeValues: allowNegativeValues);
+
+            values = values.where((value) {
+              if (widget.min != null && value < widget.min) {
+                return false;
+              }
+  
+              if (widget.max != null && value > widget.max) {
+                return false;
+              }
+              
+              return true;
+            }).toList().cast<int>();
+            
+            widget.onChanged({'text': text, 'values': values});
           });
         },
         controller: widget.controller,
         inputFormatters: [widget.textInputFormatter ?? IntegerTextInputFormatter(
-            min: widget.min,
-            max: widget.max,
-            allowNumberList: true)],
+          allowNegativeValues: allowNegativeValues,
+          allowNumberList: true
+        )],
         keyboardType: TextInputType.numberWithOptions(
           signed: allowNegativeValues,
           decimal: false

--- a/lib/widgets/common/gcw_integer_textfield.dart
+++ b/lib/widgets/common/gcw_integer_textfield.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gc_wizard/widgets/common/base/gcw_textfield.dart';
 import 'package:gc_wizard/widgets/utils/textinputformatter/integer_textinputformatter.dart';
+import 'package:gc_wizard/utils/common_utils.dart';
 
 import 'dart:math';
 
@@ -32,25 +33,38 @@ class _GCWIntegerTextFieldState extends State<GCWIntegerTextField> {
 
   @override
   Widget build(BuildContext context) {
+    var allowNegativeValues = widget.min == null || widget.min < 0;
+    
     return GCWTextField(
         hintText: widget.hintText,
         onChanged: (text) {
           setState(() {
-            var _value = ['', '-'].contains(text) ? max<int>(widget.min ?? 0, 0) : int.tryParse(text);
+            
+            List<int> values = textToIntList(text, allowNegativeValues: allowNegativeValues);
+            int value = 0;
+            
+            if (values.length > 0) {
+              
+              value = values[0];
+  
+              if (widget.min != null && value < widget.min) {
+                value = widget.min;
+              }
 
-            if (widget.min != null && _value < widget.min)
-              _value = widget.min;
+              if (widget.max != null && value > widget.max) {
+                value = widget.max;
+              }
+            } else {
+              value = 0;
+            }
 
-            if (widget.max != null && _value > widget.max)
-              _value = widget.max;
-
-            widget.onChanged({'text': text, 'value': _value});
+            widget.onChanged({'text': text, 'value': value});
           });
         },
         controller: widget.controller,
         inputFormatters: [widget.textInputFormatter ?? IntegerTextInputFormatter(
-          min: widget.min,
-          max: widget.max
+          allowNegativeValues: allowNegativeValues,
+          allowNumberList: false
         )],
         keyboardType: TextInputType.numberWithOptions(
           signed: widget.min == null || widget.min < 0,

--- a/lib/widgets/common/gcw_integer_textfield.dart
+++ b/lib/widgets/common/gcw_integer_textfield.dart
@@ -55,7 +55,13 @@ class _GCWIntegerTextFieldState extends State<GCWIntegerTextField> {
                 value = widget.max;
               }
             } else {
-              value = 0;
+              if (widget.min != null) {
+                value = widget.min;
+              } else if (widget.max) {
+                value = widget.max;
+              } else {
+                value = 0;
+              }
             }
 
             widget.onChanged({'text': text, 'value': value});

--- a/lib/widgets/tools/encodings/ascii_values.dart
+++ b/lib/widgets/tools/encodings/ascii_values.dart
@@ -67,6 +67,11 @@ class ASCIIValuesState extends State<ASCIIValues> {
 
               if (_currentMode == GCWSwitchPosition.right) {
                 var text = _currentInput['text'];
+                /**
+                 * The call to textToIntList is needed for two reasons.
+                 * First, it converts the dynamic list to an integer list, which is needed later for intListToString.
+                 * Second, when switching modes to 'right', it parses the old string and prints out only valid numbers.
+                 */
                 _currentInput = {'text': text, 'values': textToIntList(text)};
               }
 

--- a/lib/widgets/tools/encodings/ascii_values.dart
+++ b/lib/widgets/tools/encodings/ascii_values.dart
@@ -51,6 +51,8 @@ class ASCIIValuesState extends State<ASCIIValues> {
           ) :
           GCWIntegerListTextField(
             controller: _controller,
+            min: 0,
+            max: 0xffff,
             onChanged: (text) {
               setState(() {
                 _currentInput = text;

--- a/lib/widgets/tools/encodings/letter_values.dart
+++ b/lib/widgets/tools/encodings/letter_values.dart
@@ -68,6 +68,11 @@ class LetterValuesState extends State<LetterValues> {
 
               if (_currentMode == GCWSwitchPosition.right) {
                 var text = _currentInput['text'];
+                /**
+                 * The call to textToIntList is needed for two reasons.
+                 * First, it converts the dynamic list to an integer list, which is needed later for intListToString/valuesToText.
+                 * Second, when switching modes to 'right', it parses the old string and prints out only valid numbers.
+                 */
                 _currentInput = {'text': text, 'values': textToIntList(text)};
               }
 

--- a/lib/widgets/utils/textinputformatter/integer_textinputformatter.dart
+++ b/lib/widgets/utils/textinputformatter/integer_textinputformatter.dart
@@ -13,7 +13,7 @@ class IntegerTextInputFormatter extends TextInputFormatter {
       final oldSelectionIndex = oldValue.selection.end ?? 0;
       final newSelectionIndex = newValue.selection.end ?? 0;
 
-      String adaptedText = sanitizeIntegerString(newText, allowNegativeValues, allowNumberList);
+      String adaptedText = sanitizeIntegerString(newText, allowNegativeValues: allowNegativeValues, allowNumberList: allowNumberList);
 
       int adaptedSelectionIndex;
       

--- a/lib/widgets/utils/textinputformatter/integer_textinputformatter.dart
+++ b/lib/widgets/utils/textinputformatter/integer_textinputformatter.dart
@@ -1,45 +1,36 @@
 import 'package:flutter/services.dart';
+import 'package:gc_wizard/utils/common_utils.dart';
 
 class IntegerTextInputFormatter extends TextInputFormatter {
+  bool allowNegativeValues;
   bool allowNumberList;
-  int min;
-  int max;
 
-  IntegerTextInputFormatter({this.allowNumberList: false, this.min, this.max});
+  IntegerTextInputFormatter({this.allowNegativeValues: false, this.allowNumberList: false});
 
   @override TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
-    if (allowNumberList) {
-      var regex = (min == null || min < 0) ? RegExp(r'[^\-0-9]') : RegExp(r'[^0-9]');
+    
+      final String newText = newValue.text ?? '';
+      final oldSelectionIndex = oldValue.selection.end ?? 0;
+      final newSelectionIndex = newValue.selection.end ?? 0;
 
-      newValue.text.split(regex).forEach((value) {
-        if (!_checkIntegerValue(newValue.text))
-          return oldValue;
-      });
+      String adaptedText = sanitizeIntegerString(newText, allowNegativeValues, allowNumberList);
 
-      return newValue;
-
-    } else {
-      return _checkIntegerValue(newValue.text) ? newValue : oldValue;
-    }
-  }
-
-  bool _checkIntegerValue(String value) {
-    if (min != null && min >= 0 && value == '-')
-      return false;
-
-    if (value == '' || value == '-')
-      return true;
-
-    var _newInt = int.tryParse(value);
-    if (_newInt == null)
-      return false;
-
-    if (min != null && _newInt < min)
-      return false;
-
-    if (max != null && _newInt > max)
-      return false;
-
-    return true;
+      int adaptedSelectionIndex;
+      
+      if (newSelectionIndex > adaptedText.length) {
+        adaptedSelectionIndex = adaptedText.length;
+      } else {
+        if (newSelectionIndex > oldSelectionIndex) {
+          if (adaptedText.length < newText.length ) {
+            adaptedSelectionIndex = oldSelectionIndex;
+          } else {
+            adaptedSelectionIndex = newSelectionIndex;
+          }
+        } else {
+          adaptedSelectionIndex = newSelectionIndex;
+        }
+      }
+      
+      return newValue.copyWith(text: adaptedText, selection: TextSelection.fromPosition(TextPosition(offset: adaptedSelectionIndex)));
   }
 }

--- a/test/utils/common_utils.dart
+++ b/test/utils/common_utils.dart
@@ -112,4 +112,115 @@ void main() {
       });
     });
   });
+
+  group("CommonUtils.sanitizeIntegerString:", () {
+    List<Map<String, dynamic>> _inputsToExpected = [
+      {'input' : null, 'allowNegativeValues': null, 'allowNumberList' : null, 'expectedOutput' : ''},
+      
+      {'input' : '', 'allowNegativeValues': null, 'allowNumberList' : null, 'expectedOutput' : ''},
+      {'input' : null, 'allowNegativeValues': true, 'allowNumberList' : null, 'expectedOutput' : ''},
+      {'input' : null, 'allowNegativeValues': null, 'allowNumberList' : true, 'expectedOutput' : ''},
+  
+      {'input' : '', 'allowNegativeValues': true, 'allowNumberList' : null, 'expectedOutput' : ''},
+      {'input' : '', 'allowNegativeValues': null, 'allowNumberList' : true, 'expectedOutput' : ''},
+      {'input' : null, 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : ''},
+  
+      {'input' : '', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : ''},
+  
+      /** negative values, list */
+      {'input' : '1', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : '1'},
+      {'input' : '123456789', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : '123456789'},
+      {'input' : '123 456 789', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : '123 456 789'},
+      {'input' : ' 123 456 789 ', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : ' 123 456 789 '},
+  
+      {'input' : '-1', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : '-1'},
+      {'input' : '-123456789', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : '-123456789'},
+      {'input' : '-123 -456 -789', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : '-123 -456 -789'},
+      {'input' : ' -123 -456 -789 ', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : ' -123 -456 -789 '},
+  
+      {'input' : 'a-b1c', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : ' - 1 '},
+      {'input' : 'a-b1c2%=()3456789', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : ' - 1 2 3456789'},
+      {'input' : '-12(3) -4a56 -78a9', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : '-12 3 -4 56 -78 9'},
+  
+      {'input' : '         123        456      789       ', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : ' 123 456 789 '},
+  
+      {'input' : ' 123-   456-   789-   ', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : ' 123 - 456 - 789 - '},
+      {'input' : ' ---123---   ---456---   ---789---   ', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : ' ---123 --- ---456 --- ---789 --- '},
+  
+      {'input' : '-1-2-3-4-5-6-7-8-9-', 'allowNegativeValues': true, 'allowNumberList' : true, 'expectedOutput' : '-1 -2 -3 -4 -5 -6 -7 -8 -9 -'},
+  
+      /** positive values, list */
+      {'input' : '1', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : '1'},
+      {'input' : '123456789', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : '123456789'},
+      {'input' : '123 456 789', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : '123 456 789'},
+      {'input' : ' 123 456 789 ', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 123 456 789 '},
+  
+      {'input' : '-1', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 1'},
+      {'input' : '-123456789', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 123456789'},
+      {'input' : '-123 -456 -789', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 123 456 789'},
+      {'input' : ' -123 -456 -789 ', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 123 456 789 '},
+  
+      {'input' : 'a-b1c', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 1 '},
+      {'input' : 'a-b1c2%=()3456789', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 1 2 3456789'},
+      {'input' : '-12(3) -4a56 -78a9', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 12 3 4 56 78 9'},
+  
+      {'input' : '         123        456      789       ', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 123 456 789 '},
+  
+      {'input' : ' 123-   456-   789-   ', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 123 456 789 '},
+      {'input' : ' ---123---   ---456---   ---789---   ', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 123 456 789 '},
+  
+      {'input' : '-1-2-3-4-5-6-7-8-9-', 'allowNegativeValues': false, 'allowNumberList' : true, 'expectedOutput' : ' 1 2 3 4 5 6 7 8 9 '},
+  
+      /** negative values, single */
+      {'input' : '1', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '1'},
+      {'input' : '123456789', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+      {'input' : '123 456 789', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+      {'input' : ' 123 456 789 ', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+  
+      {'input' : '-1', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '-1'},
+      {'input' : '-123456789', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '-123456789'},
+      {'input' : '-123 -456 -789', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '-123456789'},
+      {'input' : ' -123 -456 -789 ', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '-123456789'},
+  
+      {'input' : 'a-b1c', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '-1'},
+      {'input' : 'a-b1c2%=()3456789', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '-123456789'},
+      {'input' : '-12(3) -4a56 -78a9', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '-123456789'},
+  
+      {'input' : '         123        456      789       ', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+  
+      {'input' : ' 123-   456-   789-   ', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+      {'input' : ' ---123---   ---456---   ---789---   ', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '-123456789'},
+  
+      {'input' : '-1-2-3-4-5-6-7-8-9-', 'allowNegativeValues': true, 'allowNumberList' : false, 'expectedOutput' : '-123456789'},
+  
+      /** positive values, single */
+      {'input' : '1', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '1'},
+      {'input' : '123456789', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+      {'input' : '123 456 789', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+      {'input' : ' 123 456 789 ', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+  
+      {'input' : '-1', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '1'},
+      {'input' : '-123456789', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+      {'input' : '-123 -456 -789', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+      {'input' : ' -123 -456 -789 ', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+  
+      {'input' : 'a-b1c', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '1'},
+      {'input' : 'a-b1c2%=()3456789', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+      {'input' : '-12(3) -4a56 -78a9', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+  
+      {'input' : '         123        456      789       ', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+  
+      {'input' : ' 123-   456-   789-   ', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+      {'input' : ' ---123---   ---456---   ---789---   ', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+  
+      {'input' : '-1-2-3-4-5-6-7-8-9-', 'allowNegativeValues': false, 'allowNumberList' : false, 'expectedOutput' : '123456789'},
+    ];
+  
+    _inputsToExpected.forEach((elem) {
+      test('input: ${elem['input']}, allowNegativeValues: ${elem['allowNegativeValues']}, allowNumberList: ${elem['allowNumberList']}', () {
+        var _actual = sanitizeIntegerString(elem['input'], allowNegativeValues: elem['allowNegativeValues'], allowNumberList: elem['allowNumberList']);
+        expect(_actual, elem['expectedOutput']);
+      });
+    });
+  });
 }


### PR DESCRIPTION
I tried to solve common problems that arise from a life-formatting Integer(List)-Input.

This is what I came up with:

- IntegerTextInputFormatter does not check for range anymore, this is done by the parser in the onChanged-callback. (Maybe we can change this, but I have to think about it again :D )
- The formatter itself works like follows:
    - Replace everything that we don't need with space
    - Cleanup (double space etc.)
    - Fix the cursor position
- Strings like `"---"` and other variations of it are still valid, but textToIntList will handle this properly.

I guess this works a bit smoother than before. However, I don't say it's perfect and there are surely some strange edge-cases I haven thought through.

But for now, I think this resolves #5 and the ideas discussed in #6 