### PR TITLE
Enhance GCWTool

### DIFF
--- a/lib/widgets/common/gcw_tool.dart
+++ b/lib/widgets/common/gcw_tool.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:gc_wizard/i18n/app_localizations.dart';
 import 'package:gc_wizard/theme/theme.dart';
+import 'package:gc_wizard/widgets/common/base/gcw_dialog.dart';
 import 'package:gc_wizard/widgets/common/gcw_symbol_container.dart';
 import 'package:gc_wizard/widgets/selector_lists/gcw_selection.dart';
 import 'package:gc_wizard/widgets/utils/common_widget_utils.dart';
@@ -16,6 +17,7 @@ class GCWTool extends StatefulWidget {
   final autoScroll;
   final iconPath;
   final String searchStrings;
+  final List buttonList;
 
   var icon;
   var _id = '';
@@ -36,7 +38,8 @@ class GCWTool extends StatefulWidget {
     this.autoScroll: true,
     this.iconPath,
     this.searchStrings: '',
-    this.titleTrailing
+    this.titleTrailing,
+    this.buttonList
   }) : super(key: key) {
     this._id = className(tool) + '_' + (i18nPrefix ?? '');
     this._isFavorite = Prefs.getStringList('favorites').contains('$_id');
@@ -69,6 +72,16 @@ class GCWTool extends StatefulWidget {
   _GCWToolState createState() => _GCWToolState();
 }
 
+class GCWToolActionButtonsEntry {
+  final bool showDialog;
+  final String url;
+  final String title;
+  final String text;
+  final IconData icon;
+
+  GCWToolActionButtonsEntry(this.showDialog, this.url, this.title, this.text, this.icon);
+}
+
 class _GCWToolState extends State<GCWTool> {
 
   @override
@@ -76,10 +89,7 @@ class _GCWToolState extends State<GCWTool> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.toolName),
-        actions: <Widget>[
-          widget.titleTrailing ?? _buildHelpButton()
-        ],
-      ),
+        actions: _buildButtons(),
       body: _buildBody()
     );
   }
@@ -102,6 +112,38 @@ class _GCWToolState extends State<GCWTool> {
     );
   }
 
+          _buildButtons() {
+    List<Widget> buttonList = new List<Widget>();
+
+    if (widget.titleTrailing.toString() != 'null')
+      return [widget.titleTrailing];
+
+    if (widget.buttonList == null)
+      return [_buildHelpButton()];
+
+    widget.buttonList.forEach((button) {
+      buttonList.add(
+          IconButton(
+            icon: Icon(button.icon),
+            onPressed: () {
+              if (button.showDialog) {
+                showGCWAlertDialog(
+                  context,
+                  i18n(context, button.title),
+                  i18n(context, button.text),
+                  () {
+                    launch(i18n(context, button.url));
+                  },
+                );
+              }
+              else
+                launch(i18n(context, button.url));
+            },
+      ));
+    });
+    return buttonList;
+  }
+      
   Widget _buildBody() {
     if (widget.tool is GCWSelection)
       return widget.tool;

--- a/lib/widgets/common/gcw_tool.dart
+++ b/lib/widgets/common/gcw_tool.dart
@@ -17,7 +17,7 @@ class GCWTool extends StatefulWidget {
   final autoScroll;
   final iconPath;
   final String searchStrings;
-  final List buttonList;
+  final List<GCWToolActionButtonsEntry> buttonList;
 
   var icon;
   var _id = '';
@@ -73,13 +73,22 @@ class GCWTool extends StatefulWidget {
 }
 
 class GCWToolActionButtonsEntry {
-  final bool showDialog;
-  final String url;
-  final String title;
-  final String text;
-  final IconData icon;
+  final bool showDialog;  // true, if the button should provide a dialog
+  final String url;       // url for a download or website
+  final String title;     // title-string to be shown in the dialog
+  final String text;      // message-text to be shown in the dialog
+  final IconData icon;    // icon tto be shown in the appbar
 
   GCWToolActionButtonsEntry(this.showDialog, this.url, this.title, this.text, this.icon);
+  // Example for usage in the registry.dart
+  //  GCWTool(
+  //    tool: Chef(),
+  //    i18nPrefix: 'chef',
+  //    searchStrings: 'chef koch rezept recipe language programming sprache esoteric esoterisch programmiersprache',
+  //    buttonList: [
+  //      GCWToolActionButtonsEntry(true, 'chef_download_documentation_url', 'chef_download_documentation_title', 'chef_download_documentation_text', Icons.file_download),
+  //      GCWToolActionButtonsEntry(false, 'chef_online_help_url', '', '', Icons.help)],
+  //  ),
 }
 
 class _GCWToolState extends State<GCWTool> {
@@ -112,33 +121,33 @@ class _GCWToolState extends State<GCWTool> {
     );
   }
 
-          _buildButtons() {
+  List<Widget>_buildButtons() {
     List<Widget> buttonList = new List<Widget>();
 
     if (widget.titleTrailing.toString() != 'null')
       return [widget.titleTrailing];
-
+  
     if (widget.buttonList == null)
       return [_buildHelpButton()];
 
     widget.buttonList.forEach((button) {
       buttonList.add(
-          IconButton(
-            icon: Icon(button.icon),
-            onPressed: () {
-              if (button.showDialog) {
-                showGCWAlertDialog(
-                  context,
-                  i18n(context, button.title),
-                  i18n(context, button.text),
-                  () {
-                    launch(i18n(context, button.url));
-                  },
-                );
-              }
-              else
-                launch(i18n(context, button.url));
-            },
+        IconButton(
+          icon: Icon(button.icon),
+          onPressed: () {
+            if (button.showDialog) {
+              showGCWAlertDialog(
+                context,
+                i18n(context, button.title),
+                i18n(context, button.text),
+                () {
+                  launch(i18n(context, button.url));
+                },
+              );
+            }
+            else
+              launch(i18n(context, button.url));
+          },
       ));
     });
     return buttonList;


### PR DESCRIPTION
**Situation**
Currently there are two different ways to add one single button in the AppBar-Widget:
1.  provide a key xxx_titleTrailing in the json-files and an IconButton-Widget
2.  provide a key _xxx_onlinehel_p in the json-files
To be more flexible and provide more than one button, the GCWTool-Widget has to be enhanced or a second, improved Widget has to be used.


**Discussion**
While initializing the GCWizard-App, the registry.dart builds al toolList = List of GCWTool.
Hence there is only one kind of widget possible.


**Recommendation**
Enhance the GCWTool-Widget to be more flexible. Thus
- provide a new field buttonList
- provide a class to initialize the buttonList in the registry
- provide a method to build the buttonList
This enhancement works with the already working keys for
- Online-Help for FormulaSolver
- Online-Help for Variable Coordinates
- download of SymbolTables-PDF
Hence there are no changes necessary - however could be done in future.


**Example**
```
GCWTool(
     tool: Chef(),
     i18nPrefix: 'chef',
     searchStrings: 'chef koch rezept recipe language programming sprache esoteric esoterisch programmiersprache',
     buttonList: [
         GCWToolActionButtonsEntry(true, 'chef_download_documentation_url', 'chef_download_documentation_title', 'chef_download_documentation_text', Icons.file_download),
         GCWToolActionButtonsEntry(false, 'chef_online_help_url', '', '', Icons.help)],
),
```
