### PR TITLE
Typo: Exact values vor MP/BP not possible --> for

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -2163,7 +2163,7 @@
   "periodictable_comment_sn": "Density is for β-Sn; α-Sn: 5.769",
   "periodictable_comment_la": "Some sources count La to Lanthanoides",
   "periodictable_comment_re": "Very weak radioactivity",
-  "periodictable_comment_os": "Exact values vor MP/BP not possible; MP: 3400 +- 50K, BP: 5300 +- 100K",
+  "periodictable_comment_os": "Exact values for MP/BP not possible; MP: 3400 +- 50K, BP: 5300 +- 100K",
   "periodictable_comment_bi": "Since 2003 classified as weakly radioactive",
   "periodictable_comment_at": "In many sources density is unknown",
   "periodictable_comment_ac": "Some sources count Ac to Actinoids",


### PR DESCRIPTION
Exact values vor MP/BP not possible; MP: 3400 +- 50K, BP: 5300 +- 100K into
Exact values for MP/BP not possible; MP: 3400 +- 50K, BP: 5300 +- 100K