### PR TITLE
Update gcw_integer_list_textfield.dart

### DIFF
--- a/lib/widgets/common/gcw_integer_list_textfield.dart
+++ b/lib/widgets/common/gcw_integer_list_textfield.dart
@@ -31,7 +31,7 @@ class _GCWIntegerListTextFieldState extends State<GCWIntegerListTextField> {
         });
       },
       controller: widget.controller,
-      inputFormatters: [WhitelistingTextInputFormatter(RegExp(r'[0-9\s]'))],
+      inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9\s]'))],
     );
   }
 }


### PR DESCRIPTION
'WhitelistingTextInputFormatter' is deprecated and shouldn't be used. Use FilteringTextInputFormatter.allow instead.
changed to FilteringTextInputFormatter.allow