### PR TITLE
bugfix-wasd

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -5301,6 +5301,8 @@
   "wasd_custom_down" : "Down",
   "wasd_custom_right" : "Right",
   "wasd_custom_left" : "Left",
+  "wasd_output_mode_g" : "Graphics",
+  "wasd_output_mode_t" : "Text, Graphics",
   "weathersymbols_title": "Weather Symbols",
   "weathersymbols_description": "Symbols and their meanings",
   "weathersymbols_a_0": "Rising then falling. Now higher than, or the same as, 3 hours ago.",

--- a/lib/widgets/tools/crypto_and_encodings/wasd.dart
+++ b/lib/widgets/tools/crypto_and_encodings/wasd.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:gc_wizard/i18n/app_localizations.dart';
 import 'package:gc_wizard/logic/tools/crypto_and_encodings/wasd.dart';
 import 'package:gc_wizard/logic/tools/images_and_files/binary2image.dart';
@@ -41,7 +42,9 @@ class WASDState extends State<WASD> {
   var _currentDown = '↓';
   var _currentRight = '→';
   var _currentMode = GCWSwitchPosition.right; // decode
+  var _currentOutputMode = GCWSwitchPosition.left; // only graphic
   var _currentKeyboardControls = WASD_TYPE.CURSORS;
+
 
   var _maskInputFormatter = WrapperForMaskTextInputFormatter(mask: '#', filter: {"#": RegExp(r'.')});
 
@@ -258,6 +261,8 @@ class WASDState extends State<WASD> {
         if (_currentMode == GCWSwitchPosition.left) // encode
           GCWTextField(
               controller: _encodeController,
+              inputFormatters: [FilteringTextInputFormatter.allow(RegExp('[0-9]')),],
+              hintText: '0123456789',
               onChanged: (text) {
                 setState(() {
                   _currentEncodeInput = text;
@@ -284,6 +289,17 @@ class WASDState extends State<WASD> {
           },
         ),
         if (_currentMode == GCWSwitchPosition.right) //decode
+          GCWTwoOptionsSwitch(
+            leftValue: i18n(context, "wasd_output_mode_g"),
+            rightValue: i18n(context, "wasd_output_mode_t"),
+            value: _currentOutputMode,
+            onChanged: (value) {
+              setState(() {
+                _currentOutputMode = value;
+              });
+            },
+          ),
+        if (_currentMode == GCWSwitchPosition.right) //decode
           GCWDefaultOutput(
               child: _buildGraphicDecodeOutput(),
               trailing: GCWIconButton(
@@ -305,7 +321,8 @@ class WASDState extends State<WASD> {
                   _outEncodeData == null ? null : _exportFile(context, _outEncodeData);
                 },
               )),
-        GCWDefaultOutput(child: _buildOutput())
+        if (_currentOutputMode == GCWSwitchPosition.right) //text & graphic
+             GCWDefaultOutput(child: _buildOutput())
       ],
     );
   }

--- a/lib/widgets/tools/crypto_and_encodings/wasd.dart
+++ b/lib/widgets/tools/crypto_and_encodings/wasd.dart
@@ -321,7 +321,8 @@ class WASDState extends State<WASD> {
                   _outEncodeData == null ? null : _exportFile(context, _outEncodeData);
                 },
               )),
-        if (_currentOutputMode == GCWSwitchPosition.right) //text & graphic
+        if (_currentMode == GCWSwitchPosition.left ||
+            (_currentMode == GCWSwitchPosition.right && _currentOutputMode == GCWSwitchPosition.right)) //text & graphic
              GCWDefaultOutput(child: _buildOutput())
       ],
     );


### PR DESCRIPTION
limit input to digits 0-9
add switch to differ between graühic and graphic/text output

reason

https://coord.info/GC9K0X7
needs a lot of time for text and graphic decoding; hence default should be graphic only
