### PR TITLE
DMS, DMM Widget DropDown fix

### DIFF
--- a/lib/common_widgets/coordinates/gcw_coords/coord_format_inputs/degrees_latlon/gcw_coords_dmm.dart
+++ b/lib/common_widgets/coordinates/gcw_coords/coord_format_inputs/degrees_latlon/gcw_coords_dmm.dart
@@ -75,12 +75,12 @@ class _GCWCoordsDMMState extends State<_GCWCoordsDMM> {
       _currentLatDegrees = lat.degrees;
       _currentLatMinutes = lat.minutes.split('.')[0];
       _currentLatMilliMinutes = lat.minutes.split('.')[1];
-      _currentLatSign = lat.sign.value;
+      _currentLatSign = lat.sign.value != 0 ? lat.sign.value : 1;
 
       _currentLonDegrees = lon.degrees;
       _currentLonMinutes = lon.minutes.split('.')[0];
       _currentLonMilliMinutes = lon.minutes.split('.')[1];
-      _currentLonSign = lon.sign.value;
+      _currentLonSign = lon.sign.value != 0 ? lon.sign.value : 1;
 
       _LatDegreesController.text = _currentLatDegrees;
       _LatMinutesController.text = _currentLatMinutes;

--- a/lib/common_widgets/coordinates/gcw_coords/coord_format_inputs/degrees_latlon/gcw_coords_dms.dart
+++ b/lib/common_widgets/coordinates/gcw_coords/coord_format_inputs/degrees_latlon/gcw_coords_dms.dart
@@ -87,13 +87,13 @@ class _GCWCoordsDMSState extends State<_GCWCoordsDMS> {
       _currentLatMinutes = lat.minutes;
       _currentLatSeconds = lat.seconds.split('.')[0];
       _currentLatMilliSeconds = lat.seconds.split('.')[1];
-      _currentLatSign = lat.sign.value;
+      _currentLatSign = lat.sign.value != 0 ? lat.sign.value : 1;
 
       _currentLonDegrees = lon.degrees;
       _currentLonMinutes = lon.minutes;
       _currentLonSeconds = lon.seconds.split('.')[0];
       _currentLonMilliSeconds = lon.seconds.split('.')[1];
-      _currentLonSign = lon.sign.value;
+      _currentLonSign = lon.sign.value != 0 ? lon.sign.value : 1;
 
       _LatDegreesController.text = _currentLatDegrees;
       _LatMinutesController.text = _currentLatMinutes;


### PR DESCRIPTION
Keine Ahnung, warum das jetz notwendig ist. Ist nur ein schneller Fix.
Vielleicht gibt es eine bessere Lösung. 
Ich konnte jedenfalls den Formatkonverter nicht mehr für die beiden Formate nutzen, weil bei sign 0 drin stand und 0 im Dropdown nicht definiert war.