### PR TITLE
Update flutter themes changes (Divider, inactive Icon color)

### DIFF
--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -101,7 +101,9 @@ ThemeData buildTheme() {
       colorScheme: ColorScheme.fromSwatch(primarySwatch: _generateMaterialColor(colors.primaryBackground()))
           .copyWith(secondary: colors.secondary(), brightness: base.brightness),
       dividerTheme: DividerThemeData(thickness: 0, color: colors.gridBackground()),
-      drawerTheme: const DrawerThemeData().copyWith(backgroundColor: base.scaffoldBackgroundColor)
+      drawerTheme: const DrawerThemeData().copyWith(backgroundColor: base.scaffoldBackgroundColor,
+          shape: const LinearBorder()),
+      switchTheme: const SwitchThemeData(trackOutlineWidth: MaterialStatePropertyAll(0))
   );
 }
 

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -101,7 +101,7 @@ ThemeData buildTheme() {
       cardColor: colors.messageBackground(),
       colorScheme: ColorScheme.fromSwatch(primarySwatch: _generateMaterialColor(colors.primaryBackground()))
           .copyWith(secondary: colors.secondary(), brightness: base.brightness, surfaceVariant: colors.gridBackground()),
-      dividerTheme: DividerThemeData(thickness: 0, color: colors.gridBackground()),
+      dividerTheme: const DividerThemeData().copyWith(thickness: 0, color: colors.gridBackground()),
       drawerTheme: const DrawerThemeData().copyWith(backgroundColor: base.scaffoldBackgroundColor));
 }
 

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -93,18 +93,14 @@ ThemeData buildTheme() {
       indicatorColor: themeColors().secondary(),
       tabBarTheme: TabBarTheme(indicatorColor: themeColors().secondary(),
           labelColor: colors.mainFont(),
-          unselectedLabelColor: colors.mainFont(),
-          indicatorSize: TabBarIndicatorSize.tab,
-          dividerHeight: 0),
+          unselectedLabelColor: colors.mainFont().withOpacity(0.7),
+          indicatorSize: TabBarIndicatorSize.tab),
       appBarTheme: AppBarTheme(backgroundColor: colors.primaryBackground(), foregroundColor: colors.mainFont()),
       cardColor: colors.messageBackground(),
       colorScheme: ColorScheme.fromSwatch(primarySwatch: _generateMaterialColor(colors.primaryBackground()))
-          .copyWith(secondary: colors.secondary(), brightness: base.brightness),
+          .copyWith(secondary: colors.secondary(), brightness: base.brightness, surfaceVariant: colors.gridBackground()),
       dividerTheme: DividerThemeData(thickness: 0, color: colors.gridBackground()),
-      drawerTheme: const DrawerThemeData().copyWith(backgroundColor: base.scaffoldBackgroundColor,
-          shape: const LinearBorder()),
-      switchTheme: const SwitchThemeData(trackOutlineWidth: MaterialStatePropertyAll(0))
-  );
+      drawerTheme: const DrawerThemeData().copyWith(backgroundColor: base.scaffoldBackgroundColor));
 }
 
 // https://medium.com/@morgenroth/using-flutters-primary-swatch-with-a-custom-materialcolor-c5e0f18b95b0

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -94,6 +94,7 @@ ThemeData buildTheme() {
       tabBarTheme: TabBarTheme(indicatorColor: themeColors().secondary(),
           labelColor: colors.mainFont(),
           unselectedLabelColor: colors.mainFont().withOpacity(0.7),
+          overlayColor: MaterialStatePropertyAll(colors.mainFont().withOpacity(0.05)),
           dividerColor: base.primaryColorDark,
           indicatorSize: TabBarIndicatorSize.tab),
       appBarTheme: AppBarTheme(backgroundColor: colors.primaryBackground(), foregroundColor: colors.mainFont()),

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -95,7 +95,7 @@ ThemeData buildTheme() {
           labelColor: colors.mainFont(),
           unselectedLabelColor: colors.mainFont().withOpacity(0.7),
           overlayColor: MaterialStatePropertyAll(colors.mainFont().withOpacity(0.05)),
-          dividerColor: base.primaryColorDark,
+          dividerHeight: 0,
           indicatorSize: TabBarIndicatorSize.tab),
       appBarTheme: AppBarTheme(backgroundColor: colors.primaryBackground(), foregroundColor: colors.mainFont()),
       cardColor: colors.messageBackground(),

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -94,6 +94,7 @@ ThemeData buildTheme() {
       tabBarTheme: TabBarTheme(indicatorColor: themeColors().secondary(),
           labelColor: colors.mainFont(),
           unselectedLabelColor: colors.mainFont().withOpacity(0.7),
+          dividerColor: base.primaryColorDark,
           indicatorSize: TabBarIndicatorSize.tab),
       appBarTheme: AppBarTheme(backgroundColor: colors.primaryBackground(), foregroundColor: colors.mainFont()),
       cardColor: colors.messageBackground(),

--- a/lib/application/theme/theme.dart
+++ b/lib/application/theme/theme.dart
@@ -63,6 +63,7 @@ ThemeData buildTheme() {
   final ThemeColors colors = themeColors();
   final ThemeData base = colors.base();
   return ThemeData(
+      useMaterial3: false,
       fontFamily: 'Roboto',
       scaffoldBackgroundColor: colors.primaryBackground(),
       textTheme: base.textTheme,
@@ -94,7 +95,6 @@ ThemeData buildTheme() {
       tabBarTheme: TabBarTheme(indicatorColor: themeColors().secondary(),
           labelColor: colors.mainFont(),
           unselectedLabelColor: colors.mainFont().withOpacity(0.7),
-          overlayColor: MaterialStatePropertyAll(colors.mainFont().withOpacity(0.05)),
           dividerHeight: 0,
           indicatorSize: TabBarIndicatorSize.tab),
       appBarTheme: AppBarTheme(backgroundColor: colors.primaryBackground(), foregroundColor: colors.mainFont()),


### PR DESCRIPTION
![296446633-038e549d-baa6-43ed-ae2a-21909371c4c1](https://github.com/S-Man42/GCWizard/assets/70719484/3a8af49a-7549-4f6a-9866-dd88b312775d)

Unfortunately I don't know what you mean. To me, the icons look exactly the same in the current web version as they do in the new one.

It is now better ? 