### PR TITLE
fixed code in symbol_table_data.dart

### DIFF
--- a/lib/tools/symbol_tables/_common/logic/symbol_table_data.dart
+++ b/lib/tools/symbol_tables/_common/logic/symbol_table_data.dart
@@ -94,7 +94,7 @@ class SymbolTableData {
 
     var jsonConfig = asJsonMap(json.decode(file));
 
-    _config.caseSensitive = jsonConfig[SymbolTableConstants.CONFIG_CASESENSITIVE] != null;
+    _config.caseSensitive = jsonConfig[SymbolTableConstants.CONFIG_CASESENSITIVE] != true;
     _config.translationPrefix = toStringOrNull(jsonConfig[SymbolTableConstants.CONFIG_TRANSLATION_PREFIX]) ?? '';
 
     if (jsonConfig[SymbolTableConstants.CONFIG_TRANSLATE] != null) {


### PR DESCRIPTION
Fixed: The setting for case_sensitive was set to true even if the config_file setting was set to false.