### PR TITLE
Fixes an iOS screen keyboard problem

### DIFF
--- a/lib/tools/symbol_tables/symbol_tables_examples_select/widget/symbol_tables_examples.dart
+++ b/lib/tools/symbol_tables/symbol_tables_examples_select/widget/symbol_tables_examples.dart
@@ -80,7 +80,13 @@ class _SymbolTableExamplesState extends State<SymbolTableExamples> {
               },
             )),
         Expanded(
-          child: _createSymbols(countColumns),
+          // dismisses the keyboard on iOS devices after editing the sample text
+          child: GestureDetector(
+            // dismisses the keyboard
+              onPanDown: (_) {
+                FocusManager.instance.primaryFocus?.unfocus();
+              },
+              child: _createSymbols(countColumns)),
         )
       ],
     );


### PR DESCRIPTION
If the sample text entry is done, the keyboard disappears now on iOS devices.
The problem appeared on the symbol_tables_examples.dart module.  There might be other tools, where the same bug appears. 