### PR TITLE
enables automatically hiding of keyboard on mobiles

### DIFF
--- a/lib/application/tools/widget/gcw_tool.dart
+++ b/lib/application/tools/widget/gcw_tool.dart
@@ -153,12 +153,20 @@ String toolName(BuildContext context, GCWTool tool) {
 class _GCWToolState extends State<GCWTool> {
   late String _toolName;
   late String _defaultLanguageToolName;
+  late FocusNode _focusNode;
 
   @override
   void initState() {
     _setToolCount(widget.longId);
+    _focusNode = FocusNode();
 
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
   }
 
   @override
@@ -178,7 +186,14 @@ class _GCWToolState extends State<GCWTool> {
             menuItemBuilder: (context) => _buildToolBarItems(),
           ) : Container()
         ]),
-        body: _buildBody());
+      body: GestureDetector(
+        onTap: () => FocusScope.of(context).requestFocus(_focusNode),
+        child: Focus(
+          focusNode: _focusNode,
+          child: _buildBody(),
+        ),
+      ),
+    );
   }
 
   String _normalizeManualSearchString(String text) {


### PR DESCRIPTION
With clicking somewhere into the body, the focus is taken from the input field.
That needs some testing.
In Enigma is an issue, because the focus is manipulated there. 
Maybe that behaviour of checking if the text is changed can be solved differently?