### PR TITLE
categorization of different waypoints on gpx import

### DIFF
--- a/lib/application/theme/fixed_colors.dart
+++ b/lib/application/theme/fixed_colors.dart
@@ -9,6 +9,9 @@ const COLOR_MAP_USERPOSITION = Colors.orange;
 const COLOR_MAP_ICONBUTTONS = Colors.black26;
 const COLOR_MAP_ACTIVATED_ICONBUTTON = Color.fromARGB(200, 255, 87, 40);
 
+const COLOR_MAP_GPX_IMPORT_PARKING = Colors.blueAccent;
+const COLOR_MAP_GPX_IMPORT_WAYPOINT = Colors.teal;
+
 const COLOR_MAP_LICENSETEXT = Color(0xFF26282F);
 const COLOR_MAP_LICENSETEXT_BACKGROUND = Colors.white;
 

--- a/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
+++ b/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
@@ -10,13 +10,11 @@ import 'package:gc_wizard/tools/coords/map_view/logic/map_geometries.dart';
 import 'package:gc_wizard/tools/coords/map_view/persistence/mapview_persistence_adapter.dart';
 import 'package:gc_wizard/tools/coords/map_view/persistence/model.dart';
 import 'package:gc_wizard/utils/constants.dart';
+import 'package:gc_wizard/application/theme/fixed_colors.dart';
 import 'package:gc_wizard/utils/file_utils/file_utils.dart';
 import 'package:gc_wizard/utils/file_utils/gcw_file.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:xml/xml.dart';
-
-const Color PARKINGCOLOR = Colors.blue;
-const Color WPTCOLOR = Colors.teal;
 
 Future<MapViewDAO?> importCoordinatesFile(GCWFile file) async {
   var type = fileTypeByFilename(file.name!);
@@ -136,9 +134,9 @@ class _GpxReader {
       if (name.isNotEmpty) {
         wpt.markerText = name;
         if (name.startsWith("P")) { // Parking coordinate only for gc.com
-          wpt.color = PARKINGCOLOR;
+          wpt.color = COLOR_MAP_GPX_IMPORT_PARKING;
         } else if (name.startsWith(RegExp('[0-9]')) || RegExp(r'-.{2}$').hasMatch(name)) { // waypoint gc.com or oc.com
-          wpt.color = WPTCOLOR;
+          wpt.color = COLOR_MAP_GPX_IMPORT_WAYPOINT;
         }
       } else {
         wpt.markerText = xmlElement.getElement('desc')?.innerText;

--- a/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
+++ b/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
@@ -15,6 +15,9 @@ import 'package:gc_wizard/utils/file_utils/gcw_file.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:xml/xml.dart';
 
+const Color PARKINGCOLOR = Colors.blue;
+const Color WPTCOLOR = Colors.teal;
+
 Future<MapViewDAO?> importCoordinatesFile(GCWFile file) async {
   var type = fileTypeByFilename(file.name!);
 
@@ -125,10 +128,19 @@ class _GpxReader {
   GCWMapPoint? _readPoint(XmlElement xmlElement) {
     var lat = xmlElement.getAttribute('lat');
     var lon = xmlElement.getAttribute('lon');
+
     if (lat != null && lon != null) {
       var wpt = GCWMapPoint(point: LatLng(double.tryParse(lat) ?? 0, double.tryParse(lon) ?? 0), isEditable: true);
-      wpt.markerText = xmlElement.getElement('name')?.innerText;
-      if (wpt.markerText == null || wpt.markerText!.isEmpty) {
+      var name = xmlElement.getElement('name')?.innerText ?? '';
+
+      if (name.isNotEmpty) {
+        wpt.markerText = name;
+        if (name.startsWith("P")) { // Parking coordinate
+          wpt.color = PARKINGCOLOR;
+        } else if (name.startsWith(RegExp('[0-9]'))) { // waypoint
+          wpt.color = WPTCOLOR;
+        }
+      } else {
         wpt.markerText = xmlElement.getElement('desc')?.innerText;
       }
       return wpt;

--- a/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
+++ b/lib/tools/coords/_common/logic/gpx_kml_gpx_import.dart
@@ -135,9 +135,9 @@ class _GpxReader {
 
       if (name.isNotEmpty) {
         wpt.markerText = name;
-        if (name.startsWith("P")) { // Parking coordinate
+        if (name.startsWith("P")) { // Parking coordinate only for gc.com
           wpt.color = PARKINGCOLOR;
-        } else if (name.startsWith(RegExp('[0-9]'))) { // waypoint
+        } else if (name.startsWith(RegExp('[0-9]')) || RegExp(r'-.{2}$').hasMatch(name)) { // waypoint gc.com or oc.com
           wpt.color = WPTCOLOR;
         }
       } else {


### PR DESCRIPTION
initial commit. original or corrected coordinates are standard black, parking coordinates are marked blue, and other waypoints are teal. I used `const Color ...` in gpx_kml_gpx_import.dart. I thought about putting it into constants.dart but that needs more libraries to import there.  Or as enum, but that's too much code for 2 colors, imho
The used colors and the names for the points are discussable. 
I tried successfully the import with Groundspeak, c:geo and Cachly GPX files