### PR TITLE
correct uppercase operations for ß

### DIFF
--- a/lib/tools/crypto_and_encodings/kenny/logic/kenny.dart
+++ b/lib/tools/crypto_and_encodings/kenny/logic/kenny.dart
@@ -89,6 +89,7 @@ String decryptKenny(String input, List<String>? replaceCharacters, bool caseSens
   }
 
   // substitute key characters/string with non-writeable characters
+
   var _input = substitution(input, substitutions, caseSensitive: false);
   int chunkStart = 0; // start position of chunk in the original text
   int chunkOffset = 0; // position in the chunk
@@ -148,7 +149,13 @@ String decryptKenny(String input, List<String>? replaceCharacters, bool caseSens
   }
   // restore unused chunks to the original text
   output = _restoreChunks(output + _input, input, 0, substitutionsSwitched);
-  if (!caseSensitive) output = output.toUpperCase();
+  if (!caseSensitive) {
+    if (output == 'ß') {
+      output = '\u1E9E';
+    } else {
+      output = output.replaceAll('ß', '\u1e9e').toUpperCase();
+    }
+  }
 
   return output;
 }

--- a/lib/tools/crypto_and_encodings/kenny/logic/kenny.dart
+++ b/lib/tools/crypto_and_encodings/kenny/logic/kenny.dart
@@ -76,6 +76,27 @@ String decryptKenny(String input, List<String>? replaceCharacters, bool caseSens
 
   var replaceToCharacters = [String.fromCharCode(0), String.fromCharCode(1), String.fromCharCode(2)];
 
+  List<String> specialHandling = [
+    'ß', // \u+00DF
+    'ﬀ', // \u+FB00
+    'ﬁ', // \u+FB01
+    'ﬂ', // \u+FB02
+    'ﬃ', // \u+FB03
+    'ﬄ', // \u+FB04
+    'ﬅ', // \u+FB05
+    'ﬆ', // \u+FB06
+  ];
+  Map<String, String> specialMapping = {
+    'ß' : String.fromCharCode(3) + String.fromCharCode(1),
+    'ﬀ' : String.fromCharCode(3) + String.fromCharCode(2),
+    'ﬁ' : String.fromCharCode(3) + String.fromCharCode(3),
+    'ﬂ' : String.fromCharCode(3) + String.fromCharCode(4),
+    'ﬃ' : String.fromCharCode(3) + String.fromCharCode(5),
+    'ﬄ' : String.fromCharCode(3) + String.fromCharCode(6),
+    'ﬅ' : String.fromCharCode(3) + String.fromCharCode(7),
+    'ﬆ' : String.fromCharCode(3) + String.fromCharCode(8),
+  };
+
   Map<String, String> substitutions = {};
   Map<String, String> substitutionsSwitched = {};
   Map<String, String> integerSubstitutions = {};
@@ -88,6 +109,10 @@ String decryptKenny(String input, List<String>? replaceCharacters, bool caseSens
     integerSubstitutions.putIfAbsent(replaceToCharacters[i], () => i.toString());
   }
 
+  // substitute special characters like 'ß' with non-writeable characters
+  for (String char in specialHandling) {
+    input = input.replaceAll(char, specialMapping[char]!);
+  }
   // substitute key characters/string with non-writeable characters
 
   var _input = substitution(input, substitutions, caseSensitive: false);
@@ -152,7 +177,12 @@ String decryptKenny(String input, List<String>? replaceCharacters, bool caseSens
   if (!caseSensitive) {
     // ('ß').toUpperCase() => 'SS' which is deprecated according to https://en.wikipedia.org/wiki/%C3%9F
     // As of 2024, when writing in capital letters, ⟨ẞ⟩ or '\u1e9e' is preferred
-    output = output.replaceAll('ß', '\u1e9e').toUpperCase();
+    // output = output.replaceAll('ß', '\u1e9e').toUpperCase();
+    output = output.toUpperCase();
+  }
+
+  for (String char in specialHandling) {
+    output = output.replaceAll(specialMapping[char]!, char);
   }
 
   return output;

--- a/lib/tools/crypto_and_encodings/kenny/logic/kenny.dart
+++ b/lib/tools/crypto_and_encodings/kenny/logic/kenny.dart
@@ -150,11 +150,9 @@ String decryptKenny(String input, List<String>? replaceCharacters, bool caseSens
   // restore unused chunks to the original text
   output = _restoreChunks(output + _input, input, 0, substitutionsSwitched);
   if (!caseSensitive) {
-    if (output == 'ß') {
-      output = '\u1E9E';
-    } else {
-      output = output.replaceAll('ß', '\u1e9e').toUpperCase();
-    }
+    // ('ß').toUpperCase() => 'SS' which is deprecated according to https://en.wikipedia.org/wiki/%C3%9F
+    // As of 2024, when writing in capital letters, ⟨ẞ⟩ or '\u1e9e' is preferred
+    output = output.replaceAll('ß', '\u1e9e').toUpperCase();
   }
 
   return output;

--- a/lib/tools/crypto_and_encodings/substitution/logic/substitution.dart
+++ b/lib/tools/crypto_and_encodings/substitution/logic/substitution.dart
@@ -5,6 +5,8 @@ String substitution(String input, Map<String, String> substitutions, {bool caseS
   if (input.isEmpty) return '';
 
   if (!caseSensitive) {
+    // ('ß').toUpperCase() => 'SS' which is deprecated according to https://en.wikipedia.org/wiki/%C3%9F
+    // As of 2024, when writing in capital letters, ⟨ẞ⟩ or '\u1e9e' is preferred
     input = input.replaceAll('ß', '\u1e9e').toUpperCase();
   }
 

--- a/lib/tools/crypto_and_encodings/substitution/logic/substitution.dart
+++ b/lib/tools/crypto_and_encodings/substitution/logic/substitution.dart
@@ -1,10 +1,11 @@
 import 'dart:collection';
 
 String substitution(String input, Map<String, String> substitutions, {bool caseSensitive = true}) {
+
   if (input.isEmpty) return '';
 
   if (!caseSensitive) {
-    input = input.toUpperCase();
+    input = input.replaceAll('ß', '\u1e9e').toUpperCase();
   }
 
   if (substitutions.keys.where((key) => key.isNotEmpty).isEmpty) return input;
@@ -62,6 +63,5 @@ String substitution(String input, Map<String, String> substitutions, {bool caseS
   for (var entry in replacements.entries) {
     if (substCopy.containsKey(entry.value)) output += substCopy[entry.value]!;
   }
-
   return output;
 }

--- a/lib/tools/crypto_and_encodings/substitution/logic/substitution.dart
+++ b/lib/tools/crypto_and_encodings/substitution/logic/substitution.dart
@@ -7,7 +7,8 @@ String substitution(String input, Map<String, String> substitutions, {bool caseS
   if (!caseSensitive) {
     // ('ß').toUpperCase() => 'SS' which is deprecated according to https://en.wikipedia.org/wiki/%C3%9F
     // As of 2024, when writing in capital letters, ⟨ẞ⟩ or '\u1e9e' is preferred
-    input = input.replaceAll('ß', '\u1e9e').toUpperCase();
+    // input = input.replaceAll('ß', '\u1e9e').toUpperCase();
+    input = input.toUpperCase();
   }
 
   if (substitutions.keys.where((key) => key.isNotEmpty).isEmpty) return input;

--- a/test/tools/crypto_and_encodings/kenny/logic/kenny_test.dart
+++ b/test/tools/crypto_and_encodings/kenny/logic/kenny_test.dart
@@ -31,6 +31,9 @@ void main() {
 
       {'input' : '1', 'replaceCharacters': ['m', 'p', 'f'], 'expectedOutput' : '1', 'caseSensitive' : true},
       {'input' : 'A1', 'replaceCharacters': ['m', 'p', 'f'], 'expectedOutput' : 'Mmm1', 'caseSensitive' : true},
+
+      {'input' : 'ß This is a test', 'replaceCharacters': ['m', 'p', 'f'], 'expectedOutput' : 'fmmfmm fmpmfpmfffmm mfffmm mmm fmpmppfmmfmp', 'caseSensitive' : false},
+      {'input' : 'ß This is a test', 'replaceCharacters': ['m', 'p', 'f'], 'expectedOutput' : 'fmmfmm Fmpmfpmfffmm mfffmm mmm fmpmppfmmfmp', 'caseSensitive' : true},
     ];
 
     for (var elem in _inputsToExpected) {
@@ -142,6 +145,9 @@ void main() {
       {'input' : 'Mpfapff', 'replaceCharacters': ['m', 'p', 'f'], 'expectedOutput' : 'FAR', 'caseSensitive' : false},
 
       {'input' : 'MfmFmffmp mfmmppppmmmmmmfmfpfmp!', 'replaceCharacters': ['m', 'p', 'f'], 'expectedOutput' : 'GUT GEMACHT!', 'caseSensitive' : false},
+
+      {'input' : 'ß Fmpmfpmfffmm mfffmm mmm fmpmppfmmfmp', 'replaceCharacters': ['m', 'p', 'f'], 'expectedOutput' : 'ẞ THIS IS A TEST', 'caseSensitive' : false},
+      {'input' : 'ß Fmpmfpmfffmm mfffmm mmm fmpmppfmmfmp', 'replaceCharacters': ['m', 'p', 'f'], 'expectedOutput' : 'ß This is a test', 'caseSensitive' : true},
     ];
 
     for (var elem in _inputsToExpected) {


### PR DESCRIPTION
it seems that the uppercase handling of ß causes the issue.
Dart converts ß to SS while the capital ⟨ẞ⟩ was encoded by Unicode in 2008 at (U+1E9E ẞ LATIN CAPITAL LETTER SHARP S).

Background
In 2017, the [Council for German Orthography](https://en.wikipedia.org/wiki/Council_for_German_Orthography) officially adopted a capital, ⟨ẞ⟩, as an acceptable variant in German orthography, ending a long orthographic debate.[[4]](https://en.wikipedia.org/wiki/%C3%9F#cite_note-Long_debate-5) Since 2024 the capital ⟨ẞ⟩ (ligature) has been preferred over ⟨SS⟩ (two letters).[[5]](https://en.wikipedia.org/wiki/%C3%9F#cite_note-Amtliches_Regelwerk-6)