### PR TITLE
Issue 2181 bugfix numeralbases 3.4.0

### DIFF
--- a/lib/application/main_menu/about_data.dart
+++ b/lib/application/main_menu/about_data.dart
@@ -120,6 +120,7 @@ const List<String> TESTER = [
   'Roland Rosenfeld',
   'schatzi-s',
   'Sechsfüssler',
+  'Skarden',
   'Stefan J.',
   'Stefan K.',
   'SzpiegDonPedro',

--- a/lib/tools/science_and_technology/numeral_bases/logic/numeral_bases.dart
+++ b/lib/tools/science_and_technology/numeral_bases/logic/numeral_bases.dart
@@ -57,7 +57,8 @@ String convertBase(String input, int startBase, int destinationBase, {String? in
     throw const FormatException('Negative Values on negative bases are not defined');
   }
 
-  var number = input.split('.');
+  // handle ',' and '.' both as decimalpoint
+  var number = input.replaceAll(',', '.').split('.');
 
   if (number.length == 2 && (destinationBase < 0 || startBase < 0)) {
     var d = _negaDoubleToDec(number[0], number[1], startBase, usedInputAlphabet);

--- a/lib/tools/science_and_technology/numeral_bases/widget/numeral_bases.dart
+++ b/lib/tools/science_and_technology/numeral_bases/widget/numeral_bases.dart
@@ -92,7 +92,8 @@ class _NumeralBasesState extends State<NumeralBases> {
 
     var calculateableToBases = _currentToMode == GCWSwitchPosition.left ? _COMMON_BASES : [_currentToKey];
     List<String> values = calculateableToBases.map((toBase) {
-      return _currentInput.split(RegExp(r'[.,\-;\s]+')).where((element) => element.isNotEmpty).map((value) {
+      return _currentInput.split(RegExp(r'[\-;\s]+')).where((element) => element.isNotEmpty).map((value) {
+        // handle ',' and '.' as decimalpoint and not as a separator of numbers
         if (value.startsWith('-') && _currentFromKey < 0) {
           return i18n(context, 'common_notdefined');
         }


### PR DESCRIPTION
handle ',' and '.' both as decimalpoint and not as separators of input